### PR TITLE
Setup jitpack

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -24,9 +24,11 @@ jobs:
       - name: Run tests
         run: sbt test
   release:
+    needs: [tests]
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -2,7 +2,7 @@ name: Cut release
 
 on:
   push:
-    branches: [setup-jitpack]
+    branches: [publish]
 
 jobs:
   tests:
@@ -19,10 +19,10 @@ jobs:
         with:
           java-version: "11"
           distribution: "adopt"
-      # - name: Compile
-      #   run: sbt compile
-      # - name: Run tests
-      #   run: sbt test
+      - name: Compile
+        run: sbt compile
+      - name: Run tests
+        run: sbt test
   release:
     needs: [tests]
     runs-on: ubuntu-latest

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,40 @@
+name: Cut release
+
+on:
+  push:
+    branches: [setup-jitpack]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up NPM 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+      - name: Compile
+        run: sbt compile
+      - name: Run tests
+        run: sbt test
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+      - name: Create release tag file
+        run: sbt createReleaseTag
+      - name: Set release tag env variable
+        run: cat tag.txt >> $GITHUB_ENV
+      - name: Check tag
+        run: echo "${{ env.RELEASE_TAG }}"

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           java-version: "11"
           distribution: "adopt"
-      - name: Compile
-        run: sbt compile
-      - name: Run tests
-        run: sbt test
+      # - name: Compile
+      #   run: sbt compile
+      # - name: Run tests
+      #   run: sbt test
   release:
     needs: [tests]
     runs-on: ubuntu-latest
@@ -40,3 +40,18 @@ jobs:
         run: cat tag.txt >> $GITHUB_ENV
       - name: Check tag
         run: echo "${{ env.RELEASE_TAG }}"
+      - name: Create Draft Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          release_name: "SAP UI5 Laminar Bindings"
+          draft: true
+          prerelease: false
+      - uses: eregon/publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_id: ${{ steps.create_release.outputs.id }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ logs
 */target
 
 *.map
+tag.txt

--- a/build.sbt
+++ b/build.sbt
@@ -21,3 +21,15 @@ lazy val `web-components` = project
       "com.raquo" %%% "laminar" % "0.14.2" % Provided
     )
   )
+
+val createReleaseTag = taskKey[java.io.File]("Writes the current release tag in tag.txt file")
+
+createReleaseTag := {
+  val file = new java.io.File("tag.txt")
+
+  val currentVersion = (`web-components` / version).value
+  val gitHash        = git.gitHeadCommit.value.toRight(new IllegalStateException("Not a git repo!")).toTry.get.take(8)
+  IO.write(file, s"RELEASE_TAG=$currentVersion-$gitHash")
+
+  file
+}

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+install:
+  - sbt web-components/publishM2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.0")


### PR DESCRIPTION
This PR configures two things:
- the small required file to make it a jitpack repo
- a github action creating releases on the `publish` branch

Both these things combined allow users to have this thing as dependency by doing:

```scala
resolvers += "jitpack" at "https://jitpack.io"

libraryDependencies ++= List(
  "com.github.sherpal" % "LaminarSAPUI5Bindings" % "1.3.0-6e2c8e33",
  "com.raquo" %%% "laminar" % "0.14.2"
)
```