### PR TITLE
Attempt to add source maps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,13 @@ val usedScalacOptions = Seq(
   "-language:higherKinds",
   "-feature",
   "-language:implicitConversions"
-)
+) ++ {
+  val localSourcesPath = baseDirectory.value.toURI
+  val remoteSourcesPath = s"https://raw.githubusercontent.com/sherpal/LaminarSAPUI5Bindings/${git.gitHeadCommit.value.get}/"
+  val sourcesOptionName = if (scalaVersion.value.startsWith("2.")) "-P:scalajs:mapSourceURI" else "-scalajs-mapSourceURI"
+
+  s"${sourcesOptionName}:$localSourcesPath->$remoteSourcesPath"
+},
 
 val laminarVersion = "0.14.5"
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,13 +10,13 @@ val usedScalacOptions = Seq(
   "-language:higherKinds",
   "-feature",
   "-language:implicitConversions"
-) ++ {
+) :+ {
   val localSourcesPath = baseDirectory.value.toURI
   val remoteSourcesPath = s"https://raw.githubusercontent.com/sherpal/LaminarSAPUI5Bindings/${git.gitHeadCommit.value.get}/"
   val sourcesOptionName = if (scalaVersion.value.startsWith("2.")) "-P:scalajs:mapSourceURI" else "-scalajs-mapSourceURI"
 
   s"${sourcesOptionName}:$localSourcesPath->$remoteSourcesPath"
-},
+}
 
 val laminarVersion = "0.14.5"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,25 @@
 import java.nio.charset.StandardCharsets
 ThisBuild / scalaVersion := "3.2.0"
 
-val usedScalacOptions = Seq(
-  "-encoding",
-  "utf8",
-  "-Xfatal-warnings",
-  "-deprecation",
-  "-unchecked",
-  "-language:higherKinds",
-  "-feature",
-  "-language:implicitConversions"
-) :+ {
+val usedScalacOptions = Def.task{
+    Seq(
+    "-encoding",
+    "utf8",
+    "-Xfatal-warnings",
+    "-deprecation",
+    "-unchecked",
+    "-language:higherKinds",
+    "-feature",
+    "-language:implicitConversions"
+  )
+}
+
+val withSourceMaps = Def.task{
   val localSourcesPath = baseDirectory.value.toURI
   val remoteSourcesPath = s"https://raw.githubusercontent.com/sherpal/LaminarSAPUI5Bindings/${git.gitHeadCommit.value.get}/"
   val sourcesOptionName = if (scalaVersion.value.startsWith("2.")) "-P:scalajs:mapSourceURI" else "-scalajs-mapSourceURI"
 
-  s"${sourcesOptionName}:$localSourcesPath->$remoteSourcesPath"
+  Seq(s"${sourcesOptionName}:$localSourcesPath->$remoteSourcesPath") ++ usedScalacOptions.value
 }
 
 val laminarVersion = "0.14.5"
@@ -43,7 +47,7 @@ lazy val `web-components-ui5` = project
   .enablePlugins(ScalaJSPlugin)
   .settings(name := "web-components-ui5")
   .settings(
-    scalacOptions ++= usedScalacOptions,
+    scalacOptions ++= withSourceMaps.value ,
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
     libraryDependencies ++= List("com.raquo" %%% "laminar" % laminarVersion % Provided),
     Compile / doc := new java.io.File("no-doc")
@@ -62,7 +66,7 @@ lazy val demo = project
   .enablePlugins(ScalaJSPlugin)
   .enablePlugins(BundleMonPlugin)
   .settings(
-    scalacOptions ++= usedScalacOptions,
+    scalacOptions ++= withSourceMaps.value,
     libraryDependencies ++= List(
       "com.raquo" %%% "laminar" % laminarVersion
     ),


### PR DESCRIPTION
Based on this line being in the sourcemap files for my app, I conclude that it's source maps are linked to it's CI runner, which is a challenge to resolve for vite / other bundler, which then Generates lots of warnings in vite. 
```
"sources": ["file:///home/runner/work/LaminarSAPUI5Bindings/LaminarSAPUI5Bindings/web-components/src/main/scala/be/doeraene/webcomponents/ui5/DatePicker.scala",
```

There is a flag to solve this, which is set in Laminar here; 
https://github.com/raquo/Laminar/blob/739cc0dbab319c685f28be30a1592b7d04347842/build.sbt#L76

This PR attempts to add the compile flag which would redirect the source maps back to this github repo, as opposed to the ephermal CI runner / release thingy-majig.

I'm not really clear how to test it outside of CI... so this PR is a hail mary... sorry for that.
