### PR TITLE
Fix source maps properly

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+      {
+          "label": "runDemo",
+          "runOptions": {
+              "runOn": "folderOpen"
+          },
+          "dependsOrder": "parallel",
+          "dependsOn": [
+              "fastLink",
+              "npmDev"              
+          ],
+          "problemMatcher": [],
+          "group": {
+              "kind": "build"
+          }
+      },
+      {
+          "label": "fastLink",
+          "type": "shell",
+          "command": "sbt \"~demo/fastLinkJS\"",
+          "presentation": {
+              "panel": "dedicated",
+              "group": "runDevCmd"
+          },
+          "group": "build"            
+      },
+      {
+          "label": "npmDev",
+          "type": "shell",
+          "command": "cd demo; npm run dev",
+          "presentation": {
+              "panel": "dedicated",
+              "group": "runDevCmd"
+          },
+          "group": "build"
+      }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -109,9 +109,13 @@ In order to run those, you need to have
 
 Perform the following steps:
 
+First time onl. Open a terminal. cd demo; npm install
+
 1. in one terminal, run `sbt ~demo/fastLinkJS`
 2. in another terminal, go to `demo` and run `npm install` then `npm run dev`
 3. when both steps are ready, go to `http://localhost:3000/laminar-ui5-demo/` and the demo should be there, waiting for you.
+
+If you're in vscode, try running the [task](https://code.visualstudio.com/docs/editor/tasks), "runDemo" build task, it will do the above 3 steps for you. 
 
 ### How to use slots?
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val usedScalacOptions = Def.task{
 }
 
 val withSourceMaps = Def.task{
-  val localSourcesPath = baseDirectory.value.toURI
+  val localSourcesPath = (LocalRootProject / baseDirectory).value.toURI.toString
   val remoteSourcesPath = s"https://raw.githubusercontent.com/sherpal/LaminarSAPUI5Bindings/${git.gitHeadCommit.value.get}/"
   val sourcesOptionName = if (scalaVersion.value.startsWith("2.")) "-P:scalajs:mapSourceURI" else "-scalajs-mapSourceURI"
 

--- a/demo/src/main/scala/demo/EntryPoint.scala
+++ b/demo/src/main/scala/demo/EntryPoint.scala
@@ -7,6 +7,7 @@ import demo.helpers.Example
 import org.scalajs.dom
 import org.scalajs.dom.{window, URL}
 
+import demo.BadgeExample
 object EntryPoint {
   def main(args: Array[String]): Unit = {
     val demoElement = {
@@ -40,6 +41,7 @@ object EntryPoint {
         LabelExample,
         LinkExample,
         ListExample,
+        MakeError,
         MediaGalleryExample,
         MenuExample,
         MessageStripExample,

--- a/demo/src/main/scala/demo/MakeError.scala
+++ b/demo/src/main/scala/demo/MakeError.scala
@@ -1,0 +1,21 @@
+package demo
+
+import be.doeraene.webcomponents.ui5.*
+import be.doeraene.webcomponents.ui5.configkeys.*
+import com.raquo.laminar.api.L.*
+import demo.helpers.{DemoPanel, Example, FetchDemoPanelFromGithub}
+
+object MakeError extends Example("MakeError") {
+
+  def component(using
+      demoPanelInfoMap: FetchDemoPanelFromGithub.CompleteDemoPanelInfo
+  ): HtmlElement = div(
+    p("press this button then have a look in the dev console at the stacktrace. You should see links to .scala files"),
+    br(),
+    Button(
+      _.design := ButtonDesign.Negative, "Default", 
+      onClick --> Observer{_ => throw new Exception("")}
+    ),
+  )
+
+}

--- a/demo/vite.config.js
+++ b/demo/vite.config.js
@@ -23,6 +23,9 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
              }
          }
      }),
-    base: "/laminar-ui5-demo/"
+    base: "/laminar-ui5-demo/",
+    server: {
+      open: '/laminar-ui5-demo'
+    }
   }
 })


### PR DESCRIPTION
Hi, 

I think this adds the source maps properly. 

I added a "MakeError" demo, which has a button which throws an exception. I think the sourcemaps do point to the right place now. 

I also included some stuff which (might) be useful for the builds, e.g. a task which kicks up all the terminals for running the demo in one hit, and also opens a tab in the browser when vite starts - I can delete if it's undesirable. 
