### PR TITLE
Bumped Laminar to 16.0.0 etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In order to use these bindings within your Scala.js project, you need to add the
 // for Scala 3
 libraryDependencies ++= List(
   "be.doeraene" %%% "web-components-ui5" % "<currently supported version>",
-  "com.raquo" %%% "laminar" % "15.0.0"
+  "com.raquo" %%% "laminar" % "16.0.0"
 )
 ```
 
@@ -27,7 +27,7 @@ or
 scalacOptions ++= List("-Ytasty-reader")
 libraryDependencies ++= List(
   "be.doeraene" % "web-components-ui5_sjs1_3" % "<currently supported version>"
-  "com.raquo" %%% "laminar" % "15.0.0"
+  "com.raquo" %%% "laminar" % "16.0.0"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import java.nio.charset.StandardCharsets
-ThisBuild / scalaVersion := "3.2.0"
+ThisBuild / scalaVersion := "3.3.0"
 
 val usedScalacOptions = Def.task{
     Seq(
@@ -22,7 +22,7 @@ val withSourceMaps = Def.task{
   Seq(s"${sourcesOptionName}:$localSourcesPath->$remoteSourcesPath") ++ usedScalacOptions.value
 }
 
-val laminarVersion = "15.0.0"
+val laminarVersion = "16.0.0"
 
 inThisBuild(
   List(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.2")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 
 addSbtPlugin("com.armanbilge" % "sbt-bundlemon" % "0.1.3")


### PR DESCRIPTION
Seems to be working (compiling) as-is. See the changes [here](https://github.com/raquo/Laminar/blob/master/website/blog/2023-07-11-laminar-v16.0.0.md) – I don't expect any of that to actually affect these bindings.

Also bumped Scala/Scala.js versions to match Laminar's requirements.