### PR TITLE
Update `Bar.js` import for UI5 web components 2.0

### DIFF
--- a/web-components/src/main/scala/be/doeraene/webcomponents/ui5/Bar.scala
+++ b/web-components/src/main/scala/be/doeraene/webcomponents/ui5/Bar.scala
@@ -27,7 +27,7 @@ object Bar extends WebComponent {
   trait RawElement extends js.Object {}
 
   @js.native
-  @JSImport("@ui5/webcomponents-fiori/dist/Bar.js", JSImport.Default)
+  @JSImport("@ui5/webcomponents/dist/Bar.js", JSImport.Default)
   object RawImport extends js.Object
 
   // object-s are lazy so you need to actually use them in your code to prevent dead code elimination


### PR DESCRIPTION
`Bar` is now in main lib, see https://sap.github.io/ui5-webcomponents/docs/migration-guides/to-version-2/#ui5-bar