### PR TITLE
WIP: Asset fetch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import java.nio.charset.StandardCharsets
-ThisBuild / scalaVersion := "3.3.1"
+ThisBuild / scalaVersion := "3.3.3"
 
 val usedScalacOptions = Def.task {
   Seq(

--- a/demo/package.json
+++ b/demo/package.json
@@ -12,10 +12,10 @@
     "vite-plugin-html": "3.2.0"
   },
   "dependencies": {
-    "@ui5/webcomponents": "2.0.1",
-    "@ui5/webcomponents-fiori": "2.0.1",
-    "@ui5/webcomponents-icons": "2.0.1",
-    "@ui5/webcomponents-compat": "2.0.1",
+    "@ui5/webcomponents": "2.2.0-rc.1",
+    "@ui5/webcomponents-fiori": "2.2.0-rc.1",
+    "@ui5/webcomponents-icons": "2.2.0-rc.1",
+    "@ui5/webcomponents-compat": "2.2.0-rc.1",
     "highlight.js": "^11.6.0"
   }
 }

--- a/web-components/src/main/scala/be/doeraene/webcomponents/ui5/globals.scala
+++ b/web-components/src/main/scala/be/doeraene/webcomponents/ui5/globals.scala
@@ -34,7 +34,7 @@ case class ListCodec[A](codec: Codec[A, String]) extends Codec[List[A], String] 
 }
 
 @js.native
-@JSImport("@ui5/webcomponents-localization/dist/Assets.js", JSImport.Namespace)
+@JSImport("@ui5/webcomponents-localization/dist/Assets-fetch.js", JSImport.Namespace)
 object Localization extends js.Object
 
 def htmlAttrWithSupport[V](name: String, codec: Codec[V, String])(support: => Any): HtmlAttr[V] = {

--- a/web-components/src/main/scala/be/doeraene/webcomponents/ui5/theming/Theming.scala
+++ b/web-components/src/main/scala/be/doeraene/webcomponents/ui5/theming/Theming.scala
@@ -26,7 +26,7 @@ object Theming {
 
   @js.native
   @JSImport(
-    "@ui5/webcomponents/dist/Assets.js",
+    "@ui5/webcomponents/dist/Assets-fetch.js",
     JSImport.Namespace
   )
   object WebComponentsAssets extends js.Object


### PR DESCRIPTION
This would be, I believe the changes that needed to be made to follow the discussion here;

https://github.com/SAP/ui5-webcomponents/discussions/9487

The hope is that it would still as before in vite, but allow the option to use a CDN if desired. i.e. to allow loading out of a CDN, bypassing the need for a bundler. As far as I can tell at the moment, this seems to work in a large % of cases.

However, apparently not with internationalisation at the moment, which is critical for `DatePicker` components for example.  

I see errors like this; when loading that page

`Unhandled Promise Rejection: Error: CLDR data for locale en_GB is not loaded!`

Which is not encouraging. At this stage unclear if;
- I have missed an import / change in the facade
- this was an oversight in the UI5 PR
- vite doesn't do this yet
- demo project needs different vite config. 

Arg...