### PR TITLE
feat: FileUploader adds file-size-exceed event

### DIFF
--- a/web-components/src/main/scala/be/doeraene/webcomponents/ui5/FileUploader.scala
+++ b/web-components/src/main/scala/be/doeraene/webcomponents/ui5/FileUploader.scala
@@ -1,33 +1,30 @@
 package be.doeraene.webcomponents.ui5
 
-import be.doeraene.webcomponents.ui5.configkeys.{ButtonDesign, ColourScheme, IconName}
-import be.doeraene.webcomponents.ui5.internal.Slot
-import com.raquo.laminar.codecs.{BooleanAsAttrPresenceCodec, IntAsStringCodec, StringAsIsCodec}
-import com.raquo.laminar.api.L.*
-import com.raquo.laminar.tags.CustomHtmlTag
-import com.raquo.laminar.keys.HtmlAttr
-import com.raquo.laminar.nodes.ReactiveHtmlElement
-import org.scalajs.dom
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSImport, JSName}
 
-import org.scalajs.dom.FileList
-import be.doeraene.webcomponents.ui5.configkeys.ValueState
-import be.doeraene.webcomponents.ui5.eventtypes.EventWithPreciseTarget
-import be.doeraene.webcomponents.ui5.eventtypes.HasDetail
 import be.doeraene.webcomponents.WebComponent
+import be.doeraene.webcomponents.ui5.configkeys.ValueState
+import be.doeraene.webcomponents.ui5.eventtypes.{EventWithPreciseTarget, HasDetail}
+import be.doeraene.webcomponents.ui5.internal.Slot
+import com.raquo.laminar.api.L.*
+import com.raquo.laminar.codecs.{BooleanAsAttrPresenceCodec, IntAsStringCodec, StringAsIsCodec}
+import com.raquo.laminar.keys.HtmlAttr
+import com.raquo.laminar.tags.CustomHtmlTag
+import org.scalajs.dom
+import org.scalajs.dom.FileList
 
 /** The ui5-file-uploader opens a file explorer dialog and enables users to upload files. The component consists of
-  * input field, but you can provide an HTML element by your choice to trigger the file upload, by using the default
-  * slot. Furthermore, you can set the property "hideInput" to "true" to hide the input field. To get all selected
-  * files, you can simply use the read-only "files" property. To restrict the types of files the user can select, you
-  * can use the "accept" property. And, similar to all input based components, the FileUploader supports "valueState",
-  * "placeholder", "name", and "disabled" properties. For the ui5-file-uploader
-  *
-  * @see
-  *   <a href="https://sap.github.io/ui5-webcomponents/playground/components/FileUploader/">the doc</a> for more
-  *   information.
-  */
+ * input field, but you can provide an HTML element by your choice to trigger the file upload, by using the default
+ * slot. Furthermore, you can set the property "hideInput" to "true" to hide the input field. To get all selected
+ * files, you can simply use the read-only "files" property. To restrict the types of files the user can select, you
+ * can use the "accept" property. And, similar to all input based components, the FileUploader supports "valueState",
+ * "placeholder", "name", and "disabled" properties. For the ui5-file-uploader
+ *
+ * @see
+ * <a href="https://sap.github.io/ui5-webcomponents/playground/components/FileUploader/">the doc</a> for more
+ * information.
+ */
 object FileUploader extends WebComponent with HasName with HasValue {
 
   @js.native
@@ -80,7 +77,22 @@ object FileUploader extends WebComponent with HasName with HasValue {
       extension (element: HasFiles) def files: List[dom.File] = element.filesJS.toList
     }
 
+    trait FileData extends js.Object {
+      val fileName: String
+      val fileSize: Int
+    }
+
+    trait FileUploaderFileSizeExceedEventDetail extends js.Object {
+      @JSName("filesData")
+      def filesDataJS: js.Array[FileData]
+    }
+
+    object FileUploaderFileSizeExceedEventDetail {
+      extension (element: FileUploaderFileSizeExceedEventDetail) def filesData: List[FileData] = element.filesDataJS.toList
+    }
+
     val onChange: EventProp[EventWithPreciseTarget[Ref] & HasDetail[HasFiles]] = new EventProp("change")
+    val onFileSizeExceed: EventProp[EventWithPreciseTarget[Ref] & HasDetail[FileUploaderFileSizeExceedEventDetail]] = new EventProp("file-size-exceed")
   }
 
 }


### PR DESCRIPTION
Follow up of #94 

This PR adds the [file-size-exceed](https://sap.github.io/ui5-webcomponents/components/FileUploader/#file-size-exceed) event for the `FileUploader` component.