### PR TITLE
Add UploadState.Complete

### DIFF
--- a/web-components/src/main/scala/be/doeraene/webcomponents/ui5/configkeys/UploadState.scala
+++ b/web-components/src/main/scala/be/doeraene/webcomponents/ui5/configkeys/UploadState.scala
@@ -5,11 +5,12 @@ sealed trait UploadState {
 }
 
 object UploadState extends EnumerationString[UploadState] {
+  case object Complete extends UploadState
   case object Ready extends UploadState
   case object Uploading extends UploadState
   case object Error extends UploadState
 
-  val allValues: List[UploadState] = List(Ready, Uploading, Error)
+  val allValues: List[UploadState] = List(Complete, Ready, Uploading, Error)
 
   def valueOf(value: UploadState): String = value.value
 }


### PR DESCRIPTION
`Complete` is also a valid value of upload state [(see docs)](https://ui5.github.io/webcomponents/components/fiori/UploadCollectionItem/#uploadstate), which hides a progress bar